### PR TITLE
fix untar for file's permission and overwriting

### DIFF
--- a/image.go
+++ b/image.go
@@ -32,9 +32,13 @@ func (i Image) Extract(dir string, overwriteSymlink bool) error {
 		return err
 	}
 	for _, blob := range layerBlobs {
-		untar.Untar(blob, dir, untar.Options{
+		err = untar.Untar(blob, dir, untar.Options{
 			OverwriteSymlinkRefs: overwriteSymlink,
 		})
+
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/untar/untar.go
+++ b/internal/untar/untar.go
@@ -65,6 +65,16 @@ func untar(r io.Reader, dir string, opts Options) error {
 
 		case f.Typeflag == tar.TypeLink:
 			os.Link(filepath.Join(dir, f.Linkname), abs)
+
+		}
+
+		if f.Typeflag != tar.TypeSymlink { // Symlink not has mode
+			if err = os.Chmod(abs, f.FileInfo().Mode()); err != nil {
+				return err
+			}
+		}
+		if err = os.Lchown(abs, f.Uid, f.Gid); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/untar/untar.go
+++ b/internal/untar/untar.go
@@ -47,7 +47,7 @@ func untar(r io.Reader, dir string, opts Options) error {
 				os.RemoveAll(rm)
 				continue
 			}
-			wf, err := os.OpenFile(abs, os.O_CREATE|os.O_RDWR, os.FileMode(f.Mode))
+			wf, err := os.OpenFile(abs, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(f.Mode))
 			if err != nil {
 				return err
 			}

--- a/internal/untar/untar.go
+++ b/internal/untar/untar.go
@@ -40,6 +40,13 @@ func untar(r io.Reader, dir string, opts Options) error {
 				}
 			}
 
+			if err = os.Chmod(abs, f.FileInfo().Mode()); err != nil {
+				return err
+			}
+			if err = os.Lchown(abs, f.Uid, f.Gid); err != nil {
+				return err
+			}
+
 		case f.Typeflag == tar.TypeReg:
 			// whiteout file
 			if strings.Contains(abs, ".wh.") {
@@ -56,6 +63,13 @@ func untar(r io.Reader, dir string, opts Options) error {
 			}
 			wf.Close()
 
+			if err = os.Chmod(abs, f.FileInfo().Mode()); err != nil {
+				return err
+			}
+			if err = os.Lchown(abs, f.Uid, f.Gid); err != nil {
+				return err
+			}
+
 		case f.Typeflag == tar.TypeSymlink:
 			if opts.OverwriteSymlinkRefs {
 				os.Symlink(filepath.Join(dir, f.Linkname), abs)
@@ -63,18 +77,19 @@ func untar(r io.Reader, dir string, opts Options) error {
 				os.Symlink(f.Linkname, abs)
 			}
 
+			if err = os.Lchown(abs, f.Uid, f.Gid); err != nil {
+				return err
+			}
+
 		case f.Typeflag == tar.TypeLink:
 			os.Link(filepath.Join(dir, f.Linkname), abs)
 
-		}
-
-		if f.Typeflag != tar.TypeSymlink { // Symlink not has mode
 			if err = os.Chmod(abs, f.FileInfo().Mode()); err != nil {
 				return err
 			}
-		}
-		if err = os.Lchown(abs, f.Uid, f.Gid); err != nil {
-			return err
+			if err = os.Lchown(abs, f.Uid, f.Gid); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
i had some below problem when *undocker extract* command.

- file's contents is broken when untar file which already exists in lower layer.
  - When `RUN echo "foobar foobar" > file` and then `RUN echo "hello" > file`, untared file is going to be`'hellor foobar'`
  - i added `os.O_TRUNC` flag to `OpenFile` func
- file's permission is different from docker image
  - i added chown/chmod after untaring files.