### PR TITLE
Write LayerBlobs to tmpfile

### DIFF
--- a/cmd/undocker/main.go
+++ b/cmd/undocker/main.go
@@ -43,6 +43,13 @@ func main() {
 			EnvVar:      "REGISTRY_PASS",
 			Destination: &opts.RegistryPass,
 		},
+		cli.StringFlag{
+			Name:        "tmpdir",
+			Value:       "/tmp/undocker",
+			Usage:       "temporal directory to extract image",
+			EnvVar:      "UNDOCKER_TMP_PATH",
+			Destination: &opts.TmpPath,
+		},
 	}
 
 	extractCommand := cli.Command{

--- a/docker_api.go
+++ b/docker_api.go
@@ -1,18 +1,18 @@
 package undocker
 
 import (
-	"io/ioutil"
 	"archive/tar"
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"strings"
 
-	"github.com/pkg/errors"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/moby/moby/client"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -90,6 +90,10 @@ func (api DockerAPI) ImageBlob(repository, tag string) (*ImageBlob, error) {
 		return nil, err
 	}
 	return &ImageBlob{Blob: blob}, err
+}
+
+func (api DockerAPI) CleanUp() error {
+	return nil
 }
 
 type ImageBlob struct {
@@ -188,4 +192,3 @@ func unmarshalManifest(r io.Reader) (Manifest, error) {
 	manifest = (*m)[0]
 	return manifest, nil
 }
-

--- a/image.go
+++ b/image.go
@@ -14,6 +14,7 @@ type Source interface {
 	Exists(repository, tag string) bool
 	LayerBlobs(repository, tag string) ([]io.Reader, error)
 	Image(repository, tag string) Image
+	CleanUp() error
 }
 
 type Image struct {

--- a/registry.go
+++ b/registry.go
@@ -123,7 +123,17 @@ func (r Registry) ExtractedBlob(repository string, digest digest.Digest) (io.Rea
 		return nil, err
 	}
 
-	tmpFilePath := filepath.Join("/tmp/undocker", digest.String())
+	tmpDirPath := "/tmp/undocker"
+
+	if stat, err := os.Stat(tmpDirPath); err != nil {
+		// file not found
+		if mkerr := os.Mkdir(tmpDirPath, 0777); mkerr != nil {
+			return nil, mkerr
+		}
+	} else if !stat.IsDir() {
+		return nil, errors.Errorf("%s must be directory", tmpDirPath)
+	}
+	tmpFilePath := filepath.Join(tmpDirPath, digest.String())
 	f, err := os.OpenFile(tmpFilePath, os.O_WRONLY|os.O_CREATE, 0777)
 	if err != nil {
 		return nil, err

--- a/undocker.go
+++ b/undocker.go
@@ -16,6 +16,7 @@ type Options struct {
 	RegistryURL  string
 	RegistryUser string
 	RegistryPass string
+	TmpPath      string
 	Extract      untar.Options
 }
 
@@ -55,9 +56,10 @@ func createSource(opts Options) (src Source, err error) {
 	url := opts.RegistryURL
 	user := opts.RegistryUser
 	pass := opts.RegistryPass
+	tmppath := opts.TmpPath
 
 	if url != "" {
-		src, err = NewRegistry(url, user, pass)
+		src, err = NewRegistry(url, user, pass, tmppath)
 	} else {
 		src, err = NewDockerAPI()
 	}

--- a/undocker.go
+++ b/undocker.go
@@ -24,6 +24,8 @@ func (u Undocker) Extract(repo, tag, dest string, opts Options) error {
 	if err != nil {
 		return err
 	}
+	defer source.CleanUp()
+
 	if err := source.Image(repo, tag).Extract(dest, opts.Extract.OverwriteSymlinkRefs); err != nil {
 		return err
 	}
@@ -35,6 +37,7 @@ func (u Undocker) Config(repo, tag string, opts Options) error {
 	if err != nil {
 		return err
 	}
+	defer source.CleanUp()
 
 	config, err := source.Image(repo, tag).Config()
 	if err != nil {


### PR DESCRIPTION
extractコマンドにて、レイヤー数多い・ファイルサイズが大きいイメージを展開しようとした際にエラーが生じるケースがありました

`net/http.Response.Body` を直接 `gzip.NewReader()` の引数に与えた際、httpのレスポンスボディを取得するのに途中で失敗した際にzipファイル展開のエラーが生じるようです

現在の実装では `Registry. LayerBlobs` で一度全レイヤーの `net/http.Response.Body` を `io.Reader` として取得した後に逐次リードして展開を行いますが、
レイヤー数が多いイメージをPullする時などにリクエストに時間がかかりすぎて途中でhttpコネクションが打ち切られるようなパターンがあり、結果として展開に失敗するようです。

各レイヤーへのGETリクエスト毎に一時ファイルに書き出すことで、問題に対処できると考えます