### PR TITLE
Fix symlink placement

### DIFF
--- a/internal/untar/untar.go
+++ b/internal/untar/untar.go
@@ -71,6 +71,12 @@ func untar(r io.Reader, dir string, opts Options) error {
 			}
 
 		case f.Typeflag == tar.TypeSymlink:
+			if _, err := os.Lstat(abs); err == nil {
+				if errRm := os.Remove(abs); errRm != nil {
+					return errRm
+				}
+			}
+
 			if opts.OverwriteSymlinkRefs {
 				if err := os.Symlink(filepath.Join(dir, f.Linkname), abs); err != nil {
 					return err

--- a/internal/untar/untar.go
+++ b/internal/untar/untar.go
@@ -72,9 +72,13 @@ func untar(r io.Reader, dir string, opts Options) error {
 
 		case f.Typeflag == tar.TypeSymlink:
 			if opts.OverwriteSymlinkRefs {
-				os.Symlink(filepath.Join(dir, f.Linkname), abs)
+				if err := os.Symlink(filepath.Join(dir, f.Linkname), abs); err != nil {
+					return err
+				}
 			} else {
-				os.Symlink(f.Linkname, abs)
+				if err := os.Symlink(f.Linkname, abs); err != nil {
+					return err
+				}
 			}
 
 			if err = os.Lchown(abs, f.Uid, f.Gid); err != nil {


### PR DESCRIPTION
Fixed an issue where error handling was not done and an error would occur when setting up a symbolic link if the file already exists.